### PR TITLE
fix: 迁移打包配置至 pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,28 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
-name = "AIcarusProtocols"
+name = "aicarus_protocols" 
 version = "1.6.0"
-description = "本库定义了 AIcarus 项目中 Core (核心) 与 Adapter (适配器) 之间进行通信所遵循的标准化事件结构。它基于 **AIcarus-Message-Protocol v1.6.0**。"
+authors = [
+  { name="Dax233", email="bakadax@qq.com" },
+]
+description = "AIcarus 项目核心与适配器之间的通信协议定义库"
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/AIcarusDev/AIcarusProtocols"
+"Bug Tracker" = "https://github.com/AIcarusDev/AIcarusProtocols/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"] 
 
 [tool.ruff]
 # 我们的代码将以 Python 3.12+ 为目标。

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,4 @@
 import setuptools
 
-with open("README.md", encoding="utf-8") as fh:
-    long_description = fh.read()
+setuptools.setup()
 
-AICARUS_PROTOCOL_VERSION = "1.6.0"  # 与你文档中的版本号保持一致
-
-setuptools.setup(
-    name="aicarus_protocols",
-    version=AICARUS_PROTOCOL_VERSION,
-    author="Dax233",
-    author_email="bakadax@qq.com",
-    description="AIcarus 项目核心与适配器之间的通信协议定义库",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/AIcarusDev/AIcarusProtocols",
-    package_dir={"": "src"},
-    packages=setuptools.find_packages(where="src"),
-    # Python 版本要求
-    python_requires=">=3.12",
-)


### PR DESCRIPTION
将项目元数据和打包配置从 setup.py 完全迁移到 pyproject.toml...

## Sourcery 总结

将所有打包和项目元数据迁移到 pyproject.toml 中，将 setup.py 简化为一个最小的存根。

增强功能：
- 将项目元数据和打包配置从 setup.py 迁移到 pyproject.toml

构建：
- 将构建系统要求和声明性元数据添加到 pyproject.toml
- 通过 pyproject.toml 中的 tool.setuptools.find 配置 setuptools 包发现

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate all packaging and project metadata into pyproject.toml, simplifying setup.py to a minimal stub.

Enhancements:
- Migrate project metadata and packaging configuration from setup.py to pyproject.toml

Build:
- Add build-system requirements and declarative metadata to pyproject.toml
- Configure setuptools package discovery via tool.setuptools.find in pyproject.toml

</details>